### PR TITLE
Fix panic and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # gh-jira-pr
 
-✨ A GitHub (`gh`) [CLI](https://cli.github.com/) extension to create GitHub pull requests based on Jira issues.
+✨ A GitHub (`gh`) [CLI](https://cli.github.com/) extension to create GitHub pull requests based on Jira issues. The pull request will then be added to the Jira task as a web link.
+
+Field mapping:
+
+- Jira issue summary     -> Pull request title
+- Jira issue description -> Pull request body
+- Jira issue subtasks    -> Pull request body tasks
+
+Note, when `--web` is used, the pull request will not be linked to the Jira issue.
 
 ## Setup
 

--- a/main.go
+++ b/main.go
@@ -67,13 +67,13 @@ func cli() error {
 
 	// Get pull request URL
 	xurlsStrict := xurls.Strict()
-	prURL := xurlsStrict.FindAllString(pr.String(), -1)[0]
+	prURL := xurlsStrict.FindAllString(pr.String(), -1)
 
 	// Update Jira issue with pull reqeust URL
-	if prURL != "" {
+	if prURL[0] != "" {
 		_, _, err = jiraClient.Issue.AddRemoteLink(ctx, *jiraIssue, &jira.RemoteLink{
 			Object: &jira.RemoteLinkObject{
-				URL:   prURL,
+				URL:   prURL[0],
 				Title: fmt.Sprintf("Pull Request: %v", issue.Fields.Summary),
 			},
 		})

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func cli() error {
 	prURL := xurlsStrict.FindAllString(pr.String(), -1)
 
 	// Update Jira issue with pull reqeust URL
-	if prURL[0] != "" {
+	if len(prURL) > 0 {
 		_, _, err = jiraClient.Issue.AddRemoteLink(ctx, *jiraIssue, &jira.RemoteLink{
 			Object: &jira.RemoteLinkObject{
 				URL:   prURL[0],


### PR DESCRIPTION
- Prevent a panic when `--web` is used. Don't attempt to link the PR to Jira issue
- Update README.md indicating how fields are mapped